### PR TITLE
fix: enable semantic commits for conventional commit compliance

### DIFF
--- a/default.json
+++ b/default.json
@@ -12,6 +12,7 @@
     "schedule:automergeNonOfficeHours",
     ":timezone(Europe/Berlin)"
   ],
+  "semanticCommits": "enabled",
   "osvVulnerabilityAlerts": true,
   "prConcurrentLimit": 5,
   "prHourlyLimit": 2,


### PR DESCRIPTION
## Summary
- Explicitly sets `"semanticCommits": "enabled"` in the shared config
- Ensures all Renovate PRs across consuming repos use conventional commit prefixes (`fix(deps):`, `chore(deps):`)
- Fixes PR title lint failures in repos that enforce commitlint with `@commitlint/config-conventional`

## Context
Auto-detection (`config:best-practices` includes `:semanticPrefixFixDepsChoreOthers`) wasn't triggering for repos without enough conventional commit history, resulting in plain titles like "Pin dependencies" instead of "fix(deps): pin dependencies".

🤖 Generated with [Claude Code](https://claude.com/claude-code)