### PR TITLE
chore(schedule): batch Renovate PRs to the last Sunday of the month

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ Extends [`config:best-practices`](https://docs.renovatebot.com/presets-config/#c
 - **7-day minimum release age** for all updates (overrides the 3-day `config:best-practices` default)
 - **OpenSSF Scorecard** badges on PRs for supply-chain visibility
 - **OSV vulnerability alerts** enabled
-- **Vulnerability PRs** skip the release-age delay and get priority `10`
+- **Vulnerability PRs** skip both the release-age delay **and** the monthly schedule (`schedule: ["at any time"]`), and get priority `10`
 - **GitHub Actions pinned to SHA digests**
 - **Major updates require dashboard approval** before PRs are created
 
@@ -44,8 +44,9 @@ Extends [`config:best-practices`](https://docs.renovatebot.com/presets-config/#c
 - **Docs dependencies grouped** into a single PR
 - **GitHub Actions grouped** into a single PR
 - **Linters, formatters, and type packages auto-merged** on minor/patch
-- **Schedule:** PRs created during non-office hours only
-- **Rate limited:** max 5 concurrent PRs, max 2 per hour
+- **Schedule:** PRs created **only on the last Sunday of the month** (Sunday between the 25th and 31st, before 6am Europe/Berlin)
+- **Automerges** are batched into the same monthly window
+- **Rate limited:** max 20 concurrent PRs, no per-hour cap (so the full monthly batch can land in one run)
 
 ### Custom managers -- `.prototools`
 
@@ -88,4 +89,6 @@ Add `packageRules` or `ignorePresets` in the repo's own `renovate.json`:
 | `:enableVulnerabilityAlerts` | Vuln alert PRs |
 | `:automergeRequireAllStatusChecks` | All CI must pass before automerge |
 | `:rebaseStalePrs` | Keep PRs up to date with base |
-| `schedule:nonOfficeHours` | Create PRs outside office hours |
+| `:timezone(Europe/Berlin)` | Schedule timezone |
+
+To opt out of the monthly schedule for a specific repo, override `schedule` and `automergeSchedule` in the repo config.

--- a/default.json
+++ b/default.json
@@ -8,14 +8,18 @@
     ":approveMajorUpdates",
     ":rebaseStalePrs",
     ":enableVulnerabilityAlerts",
-    "schedule:nonOfficeHours",
-    "schedule:automergeNonOfficeHours",
     ":timezone(Europe/Berlin)"
+  ],
+  "schedule": [
+    "before 6am on Sunday on the 25-31 of the month"
+  ],
+  "automergeSchedule": [
+    "before 6am on Sunday on the 25-31 of the month"
   ],
   "semanticCommits": "enabled",
   "osvVulnerabilityAlerts": true,
-  "prConcurrentLimit": 5,
-  "prHourlyLimit": 2,
+  "prConcurrentLimit": 20,
+  "prHourlyLimit": 0,
   "minimumReleaseAge": "7 days",
   "configMigration": true,
   "reviewersFromCodeOwners": true,
@@ -99,10 +103,11 @@
       "automerge": false
     },
     {
-      "description": "Label security/vulnerability PRs",
+      "description": "Label security/vulnerability PRs and bypass the monthly schedule so fixes ship immediately",
       "matchCategories": ["security"],
       "addLabels": ["security"],
       "minimumReleaseAge": "0 days",
+      "schedule": ["at any time"],
       "prPriority": 10
     },
     {


### PR DESCRIPTION
Concentrates all Renovate activity into a single monthly window so review load is predictable.

## Changes
- **Schedule** (`schedule` + `automergeSchedule`): `before 6am on Sunday on the 25-31 of the month` — i.e. the **last Sunday of every month**, before 6am Europe/Berlin
- Dropped the now-redundant `schedule:nonOfficeHours` and `schedule:automergeNonOfficeHours` presets
- **Rate limits raised** so the batched monthly run can clear in a single pass:
  - `prConcurrentLimit`: 5 → 20
  - `prHourlyLimit`: 2 → 0 (unlimited)
- **Security PRs** keep their priority-10 + zero release-age behavior **and** now bypass the monthly schedule via `schedule: ["at any time"]`, so vulnerability fixes still ship immediately
- README updated to reflect the new schedule and rate-limit policy

Mirrors the same change just applied to `BarretoTech/renovate-config` for consistency across both orgs.