### PR TITLE
chore(sync): align with cross-org baseline

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,22 +44,10 @@ Extends [`config:best-practices`](https://docs.renovatebot.com/presets-config/#c
 - **Docs dependencies grouped** into a single PR
 - **GitHub Actions grouped** into a single PR
 - **Linters, formatters, and type packages auto-merged** on minor/patch
-- **Schedule:** PRs created **only on the last Sunday of the month** (Sunday between the 25th and 31st, before 6am Europe/Berlin)
+- **Schedule:** PRs created **only on the last Sunday of the month** (Sunday between the 25th and 31st, before 6am Europe/Oslo)
 - **Automerges** are batched into the same monthly window
 - **Rate limited:** max 20 concurrent PRs, no per-hour cap (so the full monthly batch can land in one run)
-
-### Custom managers -- `.prototools`
-
-Regex custom managers parse tool versions from [proto](https://moonrepo.dev/proto) `.prototools` files:
-
-| Tool | Datasource | Package | Notes |
-| --- | --- | --- | --- |
-| `bun` | `github-releases` | `oven-sh/bun` | Grouped with `@types/bun` |
-| `node` | `node-version` | `node` | Uses `node` versioning (handles loose versions like `"24"`) |
-| `npm` | `npm` | `npm` | Standard npm registry |
-| `gh` | `github-releases` | `cli/cli` | GitHub CLI |
-
-Non-major updates for `node`, `npm`, and `gh` are grouped as **prototools toolchain**.
+- **`internalChecksFilter: "strict"`** — only release PRs that pass all internal checks (e.g., release-age threshold)
 
 ## Overriding for a specific repo
 
@@ -89,6 +77,6 @@ Add `packageRules` or `ignorePresets` in the repo's own `renovate.json`:
 | `:enableVulnerabilityAlerts` | Vuln alert PRs |
 | `:automergeRequireAllStatusChecks` | All CI must pass before automerge |
 | `:rebaseStalePrs` | Keep PRs up to date with base |
-| `:timezone(Europe/Berlin)` | Schedule timezone |
+| `:timezone(Europe/Oslo)` | Schedule timezone |
 
 To opt out of the monthly schedule for a specific repo, override `schedule` and `automergeSchedule` in the repo config.

--- a/default.json
+++ b/default.json
@@ -8,7 +8,7 @@
     ":approveMajorUpdates",
     ":rebaseStalePrs",
     ":enableVulnerabilityAlerts",
-    ":timezone(Europe/Berlin)"
+    ":timezone(Europe/Oslo)"
   ],
   "schedule": [
     "* 0-5 25-31 * 0"
@@ -21,51 +21,15 @@
   "prConcurrentLimit": 20,
   "prHourlyLimit": 0,
   "minimumReleaseAge": "7 days",
+  "internalChecksFilter": "strict",
   "configMigration": true,
   "reviewersFromCodeOwners": true,
   "labels": ["dependencies"],
-  "customManagers": [
-    {
-      "customType": "regex",
-      "description": "Extract bun version from .prototools",
-      "managerFilePatterns": ["/^\\.prototools$/"],
-      "matchStrings": ["bun\\s*=\\s*\"(?<currentValue>[^\"]+)\""],
-      "depNameTemplate": "oven-sh/bun",
-      "datasourceTemplate": "github-releases",
-      "extractVersionTemplate": "^bun-v(?<version>.+)$"
-    },
-    {
-      "customType": "regex",
-      "description": "Extract node version from .prototools",
-      "managerFilePatterns": ["/^\\.prototools$/"],
-      "matchStrings": ["node\\s*=\\s*\"(?<currentValue>[^\"]+)\""],
-      "depNameTemplate": "node",
-      "datasourceTemplate": "node-version",
-      "versioningTemplate": "node"
-    },
-    {
-      "customType": "regex",
-      "description": "Extract npm version from .prototools",
-      "managerFilePatterns": ["/^\\.prototools$/"],
-      "matchStrings": ["npm\\s*=\\s*\"(?<currentValue>[^\"]+)\""],
-      "depNameTemplate": "npm",
-      "datasourceTemplate": "npm"
-    },
-    {
-      "customType": "regex",
-      "description": "Extract gh (GitHub CLI) version from .prototools",
-      "managerFilePatterns": ["/^\\.prototools$/"],
-      "matchStrings": ["gh\\s*=\\s*\"(?<currentValue>[^\"]+)\""],
-      "depNameTemplate": "cli/cli",
-      "datasourceTemplate": "github-releases",
-      "extractVersionTemplate": "^v(?<version>.+)$"
-    }
-  ],
   "packageRules": [
     {
-      "description": "Group Bun runtime (.prototools) and @types/bun together",
+      "description": "Group Bun runtime (.prototools, workflow bun-version) and @types/bun together",
       "groupName": "bun",
-      "matchPackageNames": ["oven-sh/bun", "@types/bun"]
+      "matchPackageNames": ["oven-sh/bun", "@types/bun", "bun"]
     },
     {
       "description": "Group .prototools toolchain updates (node, npm, gh) together",
@@ -116,8 +80,9 @@
       "pinDigests": true
     },
     {
-      "description": "Group GitHub Actions updates",
+      "description": "Group GitHub Actions updates (excluding bun, which groups with .prototools)",
       "matchManagers": ["github-actions"],
+      "excludePackageNames": ["bun"],
       "groupName": "github-actions"
     },
     {


### PR DESCRIPTION
Mirrors the same baseline now being applied to `BarretoTech/renovate-config` ([#1](https://github.com/BarretoTech/renovate-config/pull/1)) and `archgate/renovate-config` ([#12](https://github.com/archgate/renovate-config/pull/12)).

## Changes

- **Timezone** `Europe/Berlin` → `Europe/Oslo`. Same CET/CEST window in practice, but identical across all three configs.
- **`internalChecksFilter: "strict"`** added (sourced from the archgate config).
- **`.prototools` custom managers removed.** No longer needed; native managers and workflow inputs cover the equivalent packages.
- **Bun grouping** now includes the literal `"bun"` package name so workflow `bun-version` inputs group with the runtime bump (mirrors archgate's rule).
- **GitHub Actions group** excludes `"bun"` so it stays in the bun group instead of being lumped with other action bumps.
- **README** updated: removes the `.prototools` section, swaps Berlin → Oslo, notes `internalChecksFilter`.

## What stays org-specific

- Description string
- archgate-only: `:gitSignOff`, SLSA tag-pin exemption, Java / .NET / Python / Go / Ruby groupings, `internalChecksFilter` was already there

Once this and #1 / #12 land, all three configs share the same baseline.